### PR TITLE
fixed cache invalidation when file modified in Google Drive

### DIFF
--- a/common.js
+++ b/common.js
@@ -26,10 +26,27 @@
             delete this.cache[k]
         },
         set: function(k,v) {
-            this.cache[k] = v
+            this.cache[k] = {v: v};
+            // Copy the last-modified date for later verification.
+            if (v.lastModifiedDate) {
+                this.cache[k].lastModifiedDate = v.lastModifiedDate;
+            }
         },
         get: function(k) {
-            return this.cache[k]
+            if (this.cache[k]) {
+                var v = this.cache[k].v;
+                // If the file was modified, then the file object's last-modified date
+                // will be different (greater than) the copied date. In this case the
+                // file object will have stale contents so we must invalidate the cache.
+                // This happens when reading files from Google Drive.
+                if (v.lastModifiedDate && this.cache[k].lastModifiedDate < v.lastModifiedDate) {
+                    console.log("invalidate file by lastModifiedDate");
+                    this.unset(k);
+                    return null;
+                } else {
+                    return v;
+                }
+            }
         }
     }
     _.extend(EntryCache.prototype, EntryCacheprototype)


### PR DESCRIPTION
Fixes issue #4

I noticed that when the file objects have a `lastModifiedDate` property when they are read from Google Drive but not the local filesystem. Also the date is automatically updated even though the file is not, that is, reading the file still returns the old contents. So the solution seems pretty simple: save the date along with the file and then check it when reading from the cache, and invalidate the cache if they don't match.
