### PR TITLE
Add support for index.xhtml and index.xhtm

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -277,13 +277,13 @@
                 function alldone(results) {
                     if (this.app.opts.optRenderIndex) {
                         for (var i=0; i<results.length; i++) {
-                            if (results[i].name == 'index.html' || results[i].name == 'index.htm') {
-                                this.setHeader('content-type','text/html; charset=utf-8')
+                            if (results[i].name == 'index.xhtml' || results[i].name == 'index.xhtm') {
+                                this.setHeader('content-type','application/xhtml+xml; charset=utf-8')
                                 this.renderFileContents(results[i])
                                 return
                             }
-                            else if (results[i].name == 'index.xhtml' || results[i].name == 'index.xhtm') {
-                                this.setHeader('content-type','application/xhtml+xml; charset=utf-8')
+                            else if (results[i].name == 'index.html' || results[i].name == 'index.htm') {
+                                this.setHeader('content-type','text/html; charset=utf-8')
                                 this.renderFileContents(results[i])
                                 return
                             }

--- a/handlers.js
+++ b/handlers.js
@@ -282,6 +282,11 @@
                                 this.renderFileContents(results[i])
                                 return
                             }
+                            else if (results[i].name == 'index.xhtml' || results[i].name == 'index.xhtm') {
+                                this.setHeader('content-type','application/xhtml+xml; charset=utf-8')
+                                this.renderFileContents(results[i])
+                                return
+                            }
                         }
                     }
                     if (this.request.arguments && this.request.arguments.json == '1' ||


### PR DESCRIPTION
After this patch, if "Automatically show index.html" is enabled, it will also search for "index.xhtm(l)".