### PR TITLE
Option for directory listing to show "static=1" urls

### DIFF
--- a/polymer-ui/options.js
+++ b/polymer-ui/options.js
@@ -30,6 +30,10 @@
             type: Boolean,
             default: false
         },
+        optCached: {
+        	type: Boolean,
+        	default: true
+        },
         optTryOtherPorts: {
             type: Boolean,
             default: false


### PR DESCRIPTION
Currently, that always happens. However, it can be a pain when editing stuff, so I added an option to disable it.
(This is now based off the newest version. I had a previous request based on an outdated one.)