### PR TITLE
adjusted buffers to increase performance

### DIFF
--- a/handlers.js
+++ b/handlers.js
@@ -76,7 +76,7 @@
         //this.debugInterval = setInterval( this.debug.bind(this), 1000)
         this.entry = null
         this.file = null
-        this.readChunkSize = 4096 * 16
+        this.readChunkSize = 4096 * 16 *1024
         this.fileOffset = 0
         this.fileEndOffset = 0
         this.bodyWritten = 0

--- a/stream.js
+++ b/stream.js
@@ -91,7 +91,7 @@
             }
             //console.log('tryWrite')
             this.writing = true
-            var data = this.writeBuffer.consume_any_max(4096)
+            var data = this.writeBuffer.consume_any_max(4096*1024)
             //console.log(this.sockId,'tcp.send',data.byteLength)
             //console.log(this.sockId,'tcp.send',WSC.ui82str(new Uint8Array(data)))
             sockets.tcp.send( this.sockId, data, this.onWrite.bind(this, callback) )


### PR DESCRIPTION
Hi,
i basically just tested a bit around with somewhat current hardware (i7 6000 generation) what size of buffer seems to allow a good tradeoff between performance and memory useage.
Increasing the buffers as done here, increased the performance for larger files (>prior buffer) multiple times, eg a 500mb mp4 downloads with 100MByte/s instead of 1Mbyte/s.
