### PR TITLE
Automatic folder creation during file upload

### DIFF
--- a/common.js
+++ b/common.js
@@ -128,7 +128,7 @@ if (! String.prototype.startsWith) {
     window.WSC.entryCache = new EntryCache
     window.WSC.entryFileCache = new EntryCache
 
-WSC.recursiveGetEntry = function(filesystem, path, callback) {
+WSC.recursiveGetEntry = function(filesystem, path, callback, allowFolderCreation) {
     var useCache = false
     // XXX duplication with jstorrent
     var cacheKey = filesystem.filesystem.name +
@@ -159,7 +159,7 @@ WSC.recursiveGetEntry = function(filesystem, path, callback) {
         } else if (e.isDirectory) {
             if (path.length > 1) {
                 // this is not calling error callback, simply timing out!!!
-                e.getDirectory(path.shift(), {create:false}, recurse, recurse)
+                e.getDirectory(path.shift(), {create:!!allowFolderCreation}, recurse, recurse)
             } else {
                 state.e = e
                 state.path = _.clone(path)

--- a/handlers.js
+++ b/handlers.js
@@ -104,7 +104,7 @@
 
             // if upload enabled in options...
             // check if file exists...
-            this.fs.getByPath(this.request.path, this.onPutEntry.bind(this))
+            this.fs.getByPath(this.request.path, this.onPutEntry.bind(this), true)
         },
         onPutEntry: function(entry) {
             var parts = this.request.path.split('/')

--- a/webapp.js
+++ b/webapp.js
@@ -723,14 +723,14 @@ Changes with nginx 0.7.9                                         12 Aug 2008
         this.entry = entry
     }
     _.extend(FileSystem.prototype, {
-        getByPath: function(path, callback) {
+        getByPath: function(path, callback, allowFolderCreation) {
             if (path == '/') { 
                 callback(this.entry)
                 return
             }
             var parts = path.split('/')
             var newpath = parts.slice(1,parts.length)
-            WSC.recursiveGetEntry(this.entry, newpath, callback)
+            WSC.recursiveGetEntry(this.entry, newpath, callback, allowFolderCreation)
         }
     })
 


### PR DESCRIPTION
This modification will automatically create subfolder(s) if you try to upload a file to a non-existing folder.
For example, you run the following script and 'folder1' does not exist:
$.ajax({
  url: 'http://127.0.0.1:8887/folder1/folder2/test2.txt',
  type: 'PUT',
  data: "My file Content"
});

After this HTTP request is processed 'folder1' and 'folder2' will be created (folder2 will be a subfolder of folder1). 
