### PR TITLE
Fix directory listing view in Firefox

### DIFF
--- a/directory-listing-template.html
+++ b/directory-listing-template.html
@@ -98,12 +98,14 @@ function onListingParsingError() {
 
   td.detailsColumn {
     -webkit-padding-start: 2em;
+    padding-inline-start: 2em;
     text-align: end;
     white-space: nowrap;
   }
 
   a.icon {
     -webkit-padding-start: 1.5em;
+    padding-inline-start: 1.5em;
     text-decoration: none;
   }
 


### PR DESCRIPTION
Adding non-vendor prefixed property supported in Firefox to make the directory listing not look broken.

I know this is a Chrome app, but clicking on the Web Server URL with Firefox as the default browser opens the directly listing there. The change is pretty simple.

Currently it looks like this:
<img width="187" alt="image" src="https://user-images.githubusercontent.com/817856/37554799-e8f70034-2a31-11e8-81c9-63804028e0a3.png">
