### PR TITLE
Improve POST bodies support

### DIFF
--- a/connection.js
+++ b/connection.js
@@ -90,7 +90,7 @@
                     var bodyparams = {}
                     var items = bodydata.split('&')
                     for (var i=0; i<items.length; i++) {
-                        var kv = items[i].split('=')
+                        var kv = items[i].replace(/\+/g, ' ').split('=')
                         bodyparams[ decodeURIComponent(kv[0]) ] = decodeURIComponent(kv[1])
                     }
                     req.bodyparams = bodyparams

--- a/connection.js
+++ b/connection.js
@@ -58,10 +58,12 @@
                 if (clen > 0) {
                     console.log('request had content length',clen)
                     this.stream.readBytes(clen, this.onRequestBody.bind(this))
-                    return
                 } else {
-                    this.curRequest.body = null
+                    console.log('request had an empty body')
+                    this.curRequest.body = new Uint8Array(0)
+                    this.onRequestBody(this.curRequest.body)
                 }
+                return
             }
 
             if (['GET','HEAD','PUT','OPTIONS'].includes(method)) {


### PR DESCRIPTION
* Add support for spaces in `www-form-urlencoded` bodies, by replacing `+` with spaces before decoding
  * My understanding is that a real `+` gets encoded as `%2B` and won't be impacted
* Add support for zero-length bodies, by skipping body reading, and passing a zero-length buffer through instead
  * Only when `Content-Length` is sent to begin with. Otherwise current behavior is kept.

Both changes tested by submitting `<form method="post">` bodies from Chrome.