### PR TITLE
Add support for 404 instead of dir listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a target="_blank" href="https://chrome.google.com/webstore/detail/web-server-for-chrome/ofhbbkphhbklhfoeikjpcbhemlocgigb">![Try it now in CWS](https://raw.github.com/GoogleChrome/chrome-app-samples/master/tryitnowbutton.png "Click here to install this sample from the Chrome Web Store")</a>
+<a target="_blank" href="https://chrome.google.com/webstore/detail/web-server-for-chrome/ofhbbkphhbklhfoeikjpcbhemlocgigb">![Try it now in CWS](https://raw.githubusercontent.com/kzahel/web-server-chrome/master/images/200ok-128.png "Click here to install this sample from the Chrome Web Store")</a>
 
 ## Web Server for Chrome
 

--- a/handlers.js
+++ b/handlers.js
@@ -293,12 +293,15 @@
                         (this.request.headers['accept'] && this.request.headers['accept'].toLowerCase() == 'application/json')
                        ) {
                         this.renderDirectoryListingJSON(results)
-                    } else if (this.request.arguments && this.request.arguments.static == '1' ||
+                    } else if (this.app.opts.optDir404 && this.app.opts.optRenderIndex) {
+                            this.write("404 - File not found", 404)
+                            this.finish()
+                        } else if (this.request.arguments && this.request.arguments.static == '1' ||
                         this.request.arguments.static == 'true' ||
 						this.app.opts.optStatic
                        ) {
                         this.renderDirectoryListing(results)
-                    } else {
+                        } else {
                         this.renderDirectoryListingTemplate(results)
                     }
                 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
     "short_name": "Web Server",
     "description": "A Web Server for Chrome, serves web pages from a local folder over the network, using HTTP. Runs offline.",
     "author": "Kyle Graehl",
-    "version": "0.5.0",
+    "version": "0.5.3",
     "manifest_version": 2,
     "offline_enabled": true,
     "minimum_chrome_version": "45",

--- a/react-ui/js/index.js
+++ b/react-ui/js/index.js
@@ -255,6 +255,7 @@ class App extends React.Component {
       optDoPortMapping: ['optAllInterfaces'],
       optPreventSleep: null,
       optRenderIndex: null,
+      optDir404: ['optRenderIndex'],
       port: null,
     };
     const optAdvanced = {

--- a/react-ui/js/options.js
+++ b/react-ui/js/options.js
@@ -170,6 +170,12 @@ const options = {
     type: Boolean,
     default: true
   },
+  optDir404: {
+    label: '404 instead of directory listing',
+    help: 'When no index.html is found, you will get a 404 error.',
+    type: Boolean,
+    default: false
+  },
   optUpload: {
     label: 'Allow File upload',
     help: 'The files directory listing allows drag-and-drop to upload small files',

--- a/webapp.js
+++ b/webapp.js
@@ -754,4 +754,3 @@ Changes with nginx 0.7.9                                         12 Aug 2008
     WSC.WebApplication = WebApplication
 
 })();
-


### PR DESCRIPTION
Add support for 404 instead of dir listing (#262 )

Tested by me.
I changed the version in the manifest to 2.5.3, you can change it if you like. 

It was really hard at first, but it got easier once I figured out what was where.

I also just replaced the broken image in the readme with the default logo